### PR TITLE
fix(android): fix debug build failing without keystore.properties

### DIFF
--- a/packages/android/build-and-install.sh
+++ b/packages/android/build-and-install.sh
@@ -28,7 +28,7 @@ echo "==> Building frontend..."
 bun run build
 
 echo "==> Building APK..."
-bun run tauri android build --apk
+bun run tauri android build --apk --debug
 
 APK="$SCRIPT_DIR/src-tauri/gen/android/app/build/outputs/apk/universal/debug/app-universal-debug.apk"
 if [ ! -f "$APK" ]; then

--- a/packages/android/src-tauri/gen/android/app/build.gradle.kts
+++ b/packages/android/src-tauri/gen/android/app/build.gradle.kts
@@ -33,7 +33,10 @@ android {
     }
     signingConfigs {
         create("release") {
-            storeFile = file(keystoreProperties.getProperty("storeFile", ""))
+            val sf = keystoreProperties.getProperty("storeFile", "")
+            if (sf.isNotEmpty()) {
+                storeFile = file(sf)
+            }
             storePassword = keystoreProperties.getProperty("storePassword", "")
             keyAlias = keystoreProperties.getProperty("keyAlias", "")
             keyPassword = keystoreProperties.getProperty("keyPassword", "")


### PR DESCRIPTION
### Issue for this PR

Closes #19

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `build-and-install.sh` script fails when `keystore.properties` is absent because:

1. The build command runs a **release** build (`tauri android build --apk`) which requires a signing config, but the script expects a **debug** APK path. Added `--debug` to match the intended dev workflow.
2. `build.gradle.kts` calls `file("")` when the `storeFile` property defaults to an empty string. Guarded the assignment so it's only set when the property is non-empty — prevents a crash if someone runs a release build without a keystore.

### How did you verify your code works?

Ran the full build pipeline (`bun run --cwd packages/android build` + `bun run --cwd packages/android tauri android build --apk --debug`) and confirmed the debug APK is produced at the expected path.

### Screenshots / recordings

_N/A — no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR