### PR TITLE
fix(ios): add offline recovery checkpoint with server reset flow

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -46,6 +46,7 @@ import { TerminalProvider } from "@/context/terminal"
 import DirectoryLayout from "@/pages/directory-layout"
 import Layout from "@/pages/layout"
 import { ErrorPage } from "./pages/error"
+import { usePlatform } from "@/context/platform"
 import { useCheckServerHealth } from "./utils/server-health"
 
 // UPSTREAM-DIVERGENCE-FILE: This shared app entrypoint carries the fork-only mobile push providers
@@ -176,18 +177,18 @@ function ConnectionGate(props: ParentProps<{ disableHealthCheck?: boolean }>) {
   // non-http connections, otherwise fails instantly
   const [startupHealthCheck, healthCheckActions] = createResource(() =>
     props.disableHealthCheck
-      ? true
+      ? { healthy: true } as const
       : Effect.gen(function* () {
-          if (!server.current) return true
+          if (!server.current) return { healthy: true } as const
           const { http, type } = server.current
 
           while (true) {
             const res = yield* Effect.promise(() => checkServerHealth(http))
-            if (res.healthy) return true
-            if (checkMode() === "background" || type === "http") return false
+            if (res.healthy) return { healthy: true } as const
+            if (checkMode() === "background" || type === "http") return res
           }
         }).pipe(
-          Effect.timeoutOrElse({ duration: "10 seconds", orElse: () => Effect.succeed(false) }),
+          Effect.timeoutOrElse({ duration: "10 seconds", orElse: () => Effect.succeed({ healthy: false, errorType: "timeout" } as const) }),
           Effect.ensuring(Effect.sync(() => setCheckMode("background"))),
           Effect.runPromise,
         ),
@@ -209,11 +210,12 @@ function ConnectionGate(props: ParentProps<{ disableHealthCheck?: boolean }>) {
           </div>
         }
       >*/}
-      {checkMode() === "blocking" ? startupHealthCheck() : startupHealthCheck.latest}
       <Show
-        when={startupHealthCheck()}
+        when={startupHealthCheck()?.healthy}
         fallback={
           <ConnectionError
+            errorType={(checkMode() === "blocking" ? startupHealthCheck() : startupHealthCheck.latest)?.errorType}
+            errorDetail={(checkMode() === "blocking" ? startupHealthCheck() : startupHealthCheck.latest)?.errorDetail}
             onRetry={() => {
               if (checkMode() === "background") void healthCheckActions.refetch()
             }}
@@ -232,13 +234,25 @@ function ConnectionGate(props: ParentProps<{ disableHealthCheck?: boolean }>) {
   )
 }
 
-function ConnectionError(props: { onRetry?: () => void; onServerSelected?: (key: ServerConnection.Key) => void }) {
+function ConnectionError(props: { errorType?: string; errorDetail?: string; onRetry?: () => void; onServerSelected?: (key: ServerConnection.Key) => void }) {
   const language = useLanguage()
   const server = useServer()
+  const platform = usePlatform()
   const others = () => server.list.filter((s) => ServerConnection.key(s) !== server.key)
   const name = createMemo(() => server.name || server.key)
-  const serverToken = "\u0000server\u0000"
-  const unreachable = createMemo(() => language.t("app.server.unreachable", { server: serverToken }).split(serverToken))
+  
+  const errorMessage = createMemo(() => {
+    switch (props.errorType) {
+      case "auth":
+        return "Authentication failed. The server password may be incorrect."
+      case "invalid-url":
+        return "The server URL is invalid or malformed."
+      case "timeout":
+        return "The connection timed out while trying to reach the server."
+      default:
+        return "The server is unreachable or refused the connection."
+    }
+  })
 
   const timer = setInterval(() => props.onRetry?.(), 1000)
   onCleanup(() => clearInterval(timer))
@@ -248,16 +262,20 @@ function ConnectionError(props: { onRetry?: () => void; onServerSelected?: (key:
       <div class="flex flex-col items-center max-w-md text-center">
         <Splash class="w-12 h-15 mb-4" />
         <p class="text-14-regular text-text-base">
-          {unreachable()[0]}
-          <span class="text-text-strong font-medium">{name()}</span>
-          {unreachable()[1]}
+          Cannot connect to <span class="text-text-strong font-medium">{name()}</span>
         </p>
-        <p class="mt-1 text-12-regular text-text-weak">{language.t("app.server.retrying")}</p>
+        <p class="mt-2 text-14-regular text-text-strong">
+          {errorMessage()}
+        </p>
+        <Show when={props.errorDetail}>
+          <p class="mt-1 text-12-regular text-text-weak opacity-50">{props.errorDetail}</p>
+        </Show>
+        <p class="mt-4 text-12-regular text-text-weak">{language.t("app.server.retrying")}</p>
       </div>
-      <Show when={others().length > 0}>
-        <div class="flex flex-col gap-2 w-full max-w-sm">
+      <div class="flex flex-col gap-2 w-full max-w-sm">
+        <Show when={others().length > 0}>
           <span class="text-12-regular text-text-base text-center">{language.t("app.server.otherServers")}</span>
-          <div class="flex flex-col gap-1 bg-surface-base rounded-lg p-2">
+          <div class="flex flex-col gap-1 bg-surface-base rounded-lg p-2 mb-4">
             <For each={others()}>
               {(conn) => {
                 const key = ServerConnection.key(conn)
@@ -273,8 +291,20 @@ function ConnectionError(props: { onRetry?: () => void; onServerSelected?: (key:
               }}
             </For>
           </div>
-        </div>
-      </Show>
+        </Show>
+        <button
+          type="button"
+          class="flex items-center justify-center gap-3 w-full px-3 py-3 rounded-md bg-surface-raised-base hover:bg-surface-raised-base-hover border border-border-base transition-colors"
+          onClick={() => {
+            if (platform.setDefaultServer) {
+              platform.setDefaultServer(null)
+              if (platform.restart) platform.restart()
+            }
+          }}
+        >
+          <span class="text-14-medium text-text-strong">Change Server</span>
+        </button>
+      </div>
     </div>
   )
 }

--- a/packages/app/src/utils/server-health.ts
+++ b/packages/app/src/utils/server-health.ts
@@ -2,7 +2,7 @@ import { usePlatform } from "@/context/platform"
 import type { ServerConnection } from "@/context/server"
 import { createSdkForServer } from "./server"
 
-export type ServerHealth = { healthy: boolean; version?: string }
+export type ServerHealth = { healthy: boolean; version?: string; errorType?: string; errorDetail?: string }
 
 interface CheckServerHealthOptions {
   timeoutMs?: number
@@ -75,10 +75,17 @@ export async function checkServerHealth(
   const retryCount = opts?.retryCount ?? defaultRetryCount
   const retryDelayMs = opts?.retryDelayMs ?? defaultRetryDelayMs
   const next = (count: number, error: unknown) => {
-    if (count >= retryCount || !retryable(error, signal)) return Promise.resolve({ healthy: false } as const)
+    if (count >= retryCount || !retryable(error, signal)) {
+      let type = "unreachable";
+      if (error instanceof TypeError && error.message.includes("Invalid URL")) type = "invalid-url";
+      else if (error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError")) type = "timeout";
+      else if ((error as any)?.name === "ClientError" && (error as any)?.reason === "UnexpectedStatus" && ((error as any)?.cause as any)?.status === 401) type = "auth";
+      else if ((error as any)?.name === "ClientError") type = (error as any)?.reason;
+      return Promise.resolve({ healthy: false, errorType: type, errorDetail: error instanceof Error ? error.message : String(error) } as const)
+    }
     return wait(retryDelayMs * (count + 1), signal)
       .then(() => attempt(count + 1))
-      .catch(() => ({ healthy: false }))
+      .catch(() => ({ healthy: false, errorType: 'unreachable' }))
   }
   const attempt = (count: number): Promise<ServerHealth> =>
     createSdkForServer({


### PR DESCRIPTION
### Issue for this PR

Closes #39
Might resolve #16

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On iOS/mobile, the app mounts only a single default server. When that server goes offline, the `ConnectionError` UI completely hides the "Change Server" component because the `others().length` list is empty (since there's only one server). This traps the user permanently on the error screen, requiring a full app reinstall to get back to onboarding.

This PR fixes it by explicitly checking for network/auth failure types in `checkServerHealth` and mapping them to descriptive errors. It also adds a permanent "Change Server" button to the error screen that safely calls `platform.setDefaultServer(null)` and restarts the app, letting the user go back to onboarding without getting stuck.

### How did you verify your code works?

Started a local OpenCode server with a password. Verified unauthenticated and authenticated requests. Connected the iOS Simulator to the server. Stopped the server to force the connection failure. Verified that the app falls back to the "Connection refused" error screen, tested the Retry button, and tested the Change Server button to successfully return to the onboarding screen.

### Screenshots / recordings

_UI adds a single "Change Server" button and simple text for the error reason._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
